### PR TITLE
Increase Supply Caps on BNB and Scroll

### DIFF
--- a/src/BNBCapsUpdate_20240529.s.sol
+++ b/src/BNBCapsUpdate_20240529.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3BNBAssets} from 'aave-address-book/AaveV3BNB.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardBNB} from '../scripts/CapsPlusRiskStewardBNB.s.sol';
+
+/**
+ * @title Increase Supply and Borrow Caps on Aave V3 BNB and Scroll
+ * @author Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-caps-on-aave-v3-bnb-and-scroll-05-29-2024/17825
+ */
+contract BNBCapsUpdate_20240529 is CapsPlusRiskStewardBNB {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'BNBCapsUpdate_20240529';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3BNBAssets.BTCB_UNDERLYING,
+      600,
+      EngineFlags.KEEP_CURRENT
+    );
+    return capUpdates;
+  }
+}

--- a/src/ScrollCapsUpdate_20240529.s.sol
+++ b/src/ScrollCapsUpdate_20240529.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3ScrollAssets} from 'aave-address-book/AaveV3Scroll.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardScroll} from '../scripts/CapsPlusRiskStewardScroll.s.sol';
+
+/**
+ * @title Increase Supply and Borrow Caps on Aave V3 BNB and Scroll
+ * @author Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-caps-on-aave-v3-bnb-and-scroll-05-29-2024/17825
+ */
+contract ScrollCapsUpdate_20240529 is CapsPlusRiskStewardScroll {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'ScrollCapsUpdate_20240529';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3ScrollAssets.wstETH_UNDERLYING,
+      2_000,
+      EngineFlags.KEEP_CURRENT
+    );
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-caps-on-aave-v3-bnb-and-scroll-05-29-2024/17825/1