### PR TITLE
Increase Caps for weETH on V3 Ethereum and Arbitrum

### DIFF
--- a/src/ArbitrumCapsUpdate_20240529.s.sol
+++ b/src/ArbitrumCapsUpdate_20240529.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {CapsPlusRiskStewardArbitrum} from '../scripts/CapsPlusRiskStewardArbitrum.s.sol';
+
+/**
+ * @title Increase Supply and Borrow Cap for weETH on V3 Ethereum and Arbitrum
+ * @author Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-cap-for-weeth-on-v3-ethereum-and-arbitrum-05-29-2024/17824
+ */
+contract ArbitrumCapsUpdate_20240529 is CapsPlusRiskStewardArbitrum {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'ArbitrumCapsUpdate_20240529';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3ArbitrumAssets.weETH_UNDERLYING,
+      72_000,
+      12_800
+    );
+    return capUpdates;
+  }
+}

--- a/src/MainnetCapsUpdate_20240529.s.sol
+++ b/src/MainnetCapsUpdate_20240529.s.sol
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3EthereumAssets} from 'aave-address-book/AaveV3Ethereum.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {CapsPlusRiskStewardMainnet} from '../scripts/CapsPlusRiskStewardMainnet.s.sol';
+
+/**
+ * @title Increase Supply and Borrow Cap for weETH on V3 Ethereum and Arbitrum
+ * @author Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-cap-for-weeth-on-v3-ethereum-and-arbitrum-05-29-2024/17824
+ */
+contract MainnetCapsUpdate_20240529 is CapsPlusRiskStewardMainnet {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'MainnetCapsUpdate_20240529';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3EthereumAssets.weETH_UNDERLYING,
+      300_000,
+      80_000
+    );
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-supply-and-borrow-cap-for-weeth-on-v3-ethereum-and-arbitrum-05-29-2024/17824