### PR TITLE
increase weth supply caps on arbitrum

### DIFF
--- a/diffs/pre_ArbitrumCapsUpdate_20240602_post_ArbitrumCapsUpdate_20240602.md
+++ b/diffs/pre_ArbitrumCapsUpdate_20240602_post_ArbitrumCapsUpdate_20240602.md
@@ -1,0 +1,25 @@
+## Reserve changes
+
+### Reserves altered
+
+#### WETH ([0x82aF49447D8a07e3bd95BD0d56f35241523fBab1](https://arbiscan.io/address/0x82aF49447D8a07e3bd95BD0d56f35241523fBab1))
+
+| description | value before | value after |
+| --- | --- | --- |
+| supplyCap | 100,000 WETH | 120,000 WETH |
+
+
+## Raw diff
+
+```json
+{
+  "reserves": {
+    "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1": {
+      "supplyCap": {
+        "from": 100000,
+        "to": 120000
+      }
+    }
+  }
+}
+```

--- a/src/ArbitrumCapsUpdate_20240602.s.sol
+++ b/src/ArbitrumCapsUpdate_20240602.s.sol
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {AaveV3ArbitrumAssets} from 'aave-address-book/AaveV3Arbitrum.sol';
+import {IAaveV3ConfigEngine} from 'aave-helpers/v3-config-engine/IAaveV3ConfigEngine.sol';
+import {EngineFlags} from 'aave-helpers/v3-config-engine/EngineFlags.sol';
+import {CapsPlusRiskStewardArbitrum} from '../scripts/CapsPlusRiskStewardArbitrum.s.sol';
+
+/**
+ * @title Increase WETH Supply Cap on Aave V3 Arbitrum
+ * @author Chaos Labs
+ * - Discussion: https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-weth-supply-cap-on-aave-v3-arbitrum-06-02-2024/17852/1
+ */
+contract ArbitrumCapsUpdate_20240602 is CapsPlusRiskStewardArbitrum {
+  /**
+   * @return string name identifier used for the diff
+   */
+  function name() internal pure override returns (string memory) {
+    return 'ArbitrumCapsUpdate_20240602';
+  }
+
+  /**
+   * @return IAaveV3ConfigEngine.CapsUpdate[] capUpdates to be performed
+   */
+  function capsUpdates() internal pure override returns (IAaveV3ConfigEngine.CapsUpdate[] memory) {
+    IAaveV3ConfigEngine.CapsUpdate[] memory capUpdates = new IAaveV3ConfigEngine.CapsUpdate[](1);
+
+    capUpdates[0] = IAaveV3ConfigEngine.CapsUpdate(
+      AaveV3ArbitrumAssets.WETH_UNDERLYING,
+      120_000,
+      EngineFlags.KEEP_CURRENT
+    );
+    return capUpdates;
+  }
+}


### PR DESCRIPTION
https://governance.aave.com/t/arfc-chaos-labs-risk-stewards-increase-weth-supply-cap-on-aave-v3-arbitrum-06-02-2024/17852/1